### PR TITLE
Fixed the black bar issue on the side of the screen

### DIFF
--- a/static/css/jumbotron.css
+++ b/static/css/jumbotron.css
@@ -23,6 +23,7 @@
     color: white;
     text-shadow: black 0.3em 0.3em 0.3em;
     background:transparent;
+    width: 90%;
 }
 
 .jumbotron .container {
@@ -30,3 +31,16 @@
     top: -200px;
     left: 10%;
 }
+
+@media (min-width: 300px) {
+    .jumbotron {
+        width: 100%;
+    }
+}
+
+@media (min-width: 925px) {
+    .jumbotron {
+        width: 90%;
+    }
+}
+

--- a/static/css/jumbotron.css
+++ b/static/css/jumbotron.css
@@ -23,7 +23,7 @@
     color: white;
     text-shadow: black 0.3em 0.3em 0.3em;
     background:transparent;
-    width: 90%;
+    width: 100%;
 }
 
 .jumbotron .container {
@@ -32,13 +32,7 @@
     left: 10%;
 }
 
-@media (min-width: 300px) {
-    .jumbotron {
-        width: 100%;
-    }
-}
-
-@media (min-width: 925px) {
+@media (min-width: 625px) {
     .jumbotron {
         width: 90%;
     }


### PR DESCRIPTION
### Problem / Feature
Black bar down the side of Safari after going desktop-mobile-desktop.
### Solution
Changed the width of the Jumbotron in Jumbotron.css
### What To Test
Make sure the title looks the same, works on mobile, and that the screen doesn't make a black bar on any other browsers, or wider screens.

### Reviewers

@REVIEWER

FYI: @KrashLeviathan @csteamengine @regalcat